### PR TITLE
refact: excluding appName property from BaseClient

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -11,13 +11,14 @@ import { ClientOptions } from './types';
 import { converterPathParamsUrl } from './utils';
 
 export class BaseClient implements BaseClientInterface {
+  appName: string;
   client: any;
   clientOptions: ClientOptions;
   auth: object;
   retryAuth: boolean;
 
   constructor(clientOptions: ClientOptions) {
-    clientOptions.appName = this.constructor.name;
+    this.appName = this.constructor.name;
     this.clientOptions = clientOptions;
     this.auth = {};
     this.retryAuth = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,6 @@
  * }
  */
 export type ClientOptions = {
-  appName?: string;
   authProvider?: any;
   forceAuth?: boolean;
   timeout?: number;

--- a/tests/axios.test.ts
+++ b/tests/axios.test.ts
@@ -31,7 +31,6 @@ describe('AxiosClient', () => {
   beforeEach(() => {
     clientBasic = new AxiosClient({
       baseURL: 'https://api.example.com/v1',
-      appName: 'example',
       authProvider: null,
       endpoints,
       retryDelay: 3,

--- a/tests/base.test.ts
+++ b/tests/base.test.ts
@@ -16,7 +16,6 @@ describe('BaseClient', () => {
   let clientBasic: BaseClient;
   beforeEach(() => {
     clientBasic = new BaseClient({
-      appName: 'example',
       authProvider: null,
       endpoints
     });
@@ -29,7 +28,6 @@ describe('BaseClient', () => {
     [3, 3]
   ])('default retryDelay shoud be %i when defined %o', (expected, value) => {
     const client = new BaseClient({
-      appName: 'example',
       authProvider: null,
       endpoints,
       retryDelay: value,
@@ -47,7 +45,6 @@ describe('BaseClient', () => {
     [3, 3]
   ])('default tries shoud be %i when defined %o', (expected, value) => {
     const client = new BaseClient({
-      appName: 'example',
       authProvider: null,
       endpoints,
       tries: value,
@@ -64,7 +61,6 @@ describe('BaseClient', () => {
     [1000, 1000]
   ])('default timeout shoud be %i when defined %o', (expected, value) => {
     const client = new BaseClient({
-      appName: 'example',
       authProvider: null,
       endpoints,
       retryDelay: 3,

--- a/tests/zendesk.test.ts
+++ b/tests/zendesk.test.ts
@@ -41,8 +41,8 @@ describe('ZendeskClientBase', () => {
 
       expect(instance).toBeDefined();
       expect(instance.client).toBe(mockZendeskClient);
+      expect(instance.appName).toBe(instance.constructor.name);
       expect(instance.clientOptions).toEqual({
-        appName: instance.constructor.name,
         endpoints: {},
         secure: secureValue,
         client: mockZendeskClient,


### PR DESCRIPTION
**Description:**
 Exclusão da propriedade appName, na instanciação de novos clientes dependentes da classe pai **BaseClient**
 A Propriedade estava sendo sobreesctrita, pelo nome da classe instanciada, tornando inútil a informação passada via Constructor.

A propriedade agora é um atributo da classe **BaseClient**, inicializado diretamente na classe, com o nome da classe Filha.

**Type of change:**

- [✅] Bug fix (non-breaking change which fixes an issue)

**Why is this change required?:**
Tornar mais clara a utilização da Lib,  e menos passível a erros.

Client para requisições HTTP via Axios Client sem a propriedade appName.
```typescript 
import { AxiosClient } from './src/axios'

import { AxiosResponse } from 'axios';

export class GithubClient extends AxiosClient {
  constructor(baseURL: string) {
    super({
      baseURL,
      endpoints: {
        fetch: '/users/{id}'
      }
    });
  }
}

const newInstance = new GithubClient('https://api.github.com')
newInstance.fetch('MatheusDev20').then(({data}) => {
    console.log(`ID => ${data.id}`)
})
```
A mudança também reflete na instanciação de classes dependentes da classe ZendeskClient, onde somente o cliente zendesk (ZAF) é necessário ser passado via construtor.

**Checklist:**

- [✅ ] My code follows the code style of this project.
- [✅ ] I have added tests to cover my changes.
- [✅] All new and existing tests passed.
- 
