### PR TITLE
Fix/add data and content type zendesk

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -155,7 +155,8 @@ export type PayloadRequestZendesk = {
   method: string;
   pathParams?: object;
   queryParams?: object;
-  data?: object;
+  contentType?: string;
+  data?: object | string;
   options?: object;
   headers?: object;
   retryCount?: number;

--- a/src/zendesk.ts
+++ b/src/zendesk.ts
@@ -39,8 +39,11 @@ export class ZendeskClient
         url: payload.url,
         method: payload.method,
         secure: this.isProduction,
-        contentType: 'application/x-www-form-urlencoded',
-        httpCompleteResponse: true
+        contentType: payload.contentType
+          ? payload.contentType
+          : 'application/x-www-form-urlencoded',
+        httpCompleteResponse: true,
+        ...(payload.data && { data: payload.data })
       });
     } catch (error) {
       if (!error.status) throw new Error(String(error));

--- a/tests/zendesk.test.ts
+++ b/tests/zendesk.test.ts
@@ -326,4 +326,41 @@ describe('ZendeskClientBase', () => {
       expect(mockZendeskClient.request).toHaveBeenCalledTimes(1);
     }
   );
+
+  it('should call makeRequest with the correct ContentType', async () => {
+    const expectedContentType = 'application/json';
+    const payload: PayloadRequestZendesk = {
+      url: 'url',
+      method: 'method',
+      contentType: 'application/json'
+    };
+    await zendeskClientBase.makeRequest(payload);
+    delete payload.retryCount;
+    expect(mockZendeskClient.request).toHaveBeenCalledWith({
+      ...payload,
+      secure: false,
+      contentType: expectedContentType,
+      httpCompleteResponse: true
+    });
+    expect(mockZendeskClient.request).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call makeRequest with the correct data', async () => {
+    const expectedData = { id: '1' };
+    const payload: PayloadRequestZendesk = {
+      url: 'url',
+      method: 'method',
+      data: { id: '1' }
+    };
+    await zendeskClientBase.makeRequest(payload);
+    delete payload.retryCount;
+    expect(mockZendeskClient.request).toHaveBeenCalledWith({
+      ...payload,
+      secure: false,
+      data: expectedData,
+      httpCompleteResponse: true,
+      contentType: 'application/x-www-form-urlencoded'
+    });
+    expect(mockZendeskClient.request).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Resolves [#39 ](https://github.com/Coaktion/client-core/issues/39)

**Description:**
In the makeRequest method, the contentType is hardcoded to 'application/x-www-form-urlencoded'. Additionally, the 'data' parameter isn't being set, even when provided as an argument.

**Type of change:**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
To have the flexibility to specify various contentTypes and utilize HTTP methods beyond just GET with ZAF.request.

---

**Checklist:**

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
