### PR TITLE
Feat/add fetch all method

### DIFF
--- a/src/axios.ts
+++ b/src/axios.ts
@@ -3,7 +3,7 @@ import axiosRetry from 'axios-retry';
 
 import { BaseClient } from './base';
 import { AxiosClientInterface } from './interfaces';
-import { ClientOptionsAxios, DataOptions } from './types';
+import { ClientOptionsAxios, Payload } from './types';
 
 export class AxiosClient extends BaseClient implements AxiosClientInterface {
   clientOptions: ClientOptionsAxios;
@@ -29,9 +29,11 @@ export class AxiosClient extends BaseClient implements AxiosClientInterface {
    * @description
    * If the endpoint is not set, it will throw an error
    * Otherwise, it will make a request to the endpoint
-   * @param {string} methodName The method name to use for the request
-   * @param {string} endpoint The endpoint to use for the request
-   * @param {DataOptions} [dataOptions] The data options to use for the request
+   * @param {string} method - The method to use for the request
+   * @param {string} url - The url to use for the request
+   * @param {object} [data] - The data to use for the request
+   * @param {object} [params] - The params to use for the request
+   * @param {object} [headers] - The headers to use for the request
    * @returns {Promise<AxiosResponse>} The response from the request
    * @memberof BasicClient
    * @throws {EndpointNotSet}
@@ -42,22 +44,23 @@ export class AxiosClient extends BaseClient implements AxiosClientInterface {
    * console.log(response.data);
    * // => { id: 1, name: 'test' }
    */
-  async makeRequest(
-    methodName: string,
-    endpoint: string,
-    dataOptions?: DataOptions,
-    headers?: object
-  ): Promise<AxiosResponse> {
+  async makeRequest({
+    method,
+    url,
+    data,
+    params,
+    headers
+  }: Payload): Promise<AxiosResponse> {
     if (this.clientOptions.forceAuth || this.retryAuth)
       await this.authentication();
 
     headers = { ...this.auth, ...headers };
     return this.client.request({
-      method: methodName,
-      url: endpoint,
+      method,
+      url,
       timeout: this.clientOptions.timeout,
-      data: dataOptions?.data,
-      params: dataOptions?.params,
+      data,
+      params,
       headers
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,7 @@ export {
   AuthOptions,
   BearerAuthOptions,
   ClientOptions,
-  Endpoints,
-  DataOptions
+  Endpoints
 } from './types';
 export {
   EndpointNotSet,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,8 +3,8 @@ import { AxiosError, AxiosInstance, AxiosResponse } from 'axios';
 import {
   AuthOptions,
   ClientOptions,
-  DataOptions,
   ModalProps,
+  Payload,
   PayloadRequestZendesk
 } from './types';
 
@@ -50,18 +50,17 @@ export interface BaseClientInterface {
   search(params?: object): Promise<AxiosResponse | any>;
   fetch(id: string): Promise<AxiosResponse | any>;
   create(data: object): Promise<AxiosResponse | any>;
-  update(id: string, data: object): Promise<AxiosResponse | any>;
+  update(
+    id: string,
+    data: object | string,
+    method: string
+  ): Promise<AxiosResponse | any>;
   delete(id: string): Promise<AxiosResponse | any>;
 }
 export interface AxiosClientInterface extends BaseClientInterface {
   client: AxiosInstance;
 
-  makeRequest(
-    methodName: string,
-    endpoint: string,
-    dataOptions?: DataOptions,
-    headers?: object
-  ): Promise<AxiosResponse>;
+  makeRequest(data: Payload): Promise<AxiosResponse>;
   retryDelay(retryCount: number, error: AxiosError): number;
   retryCondition(error: AxiosError): boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export type ClientOptionsAxios = ClientOptions & {
  * @description Type for Endpoints
  * @typedef Endpoints
  * @property {string} [search] - The endpoint to use for searching
+ * @property {string} [searchAllPages] - The endpoint to use for searching all pages
  * @property {string} [fetch] - The endpoint to use for fetching
  * @property {string} [create] - The endpoint to use for creating
  * @property {string} [update] - The endpoint to use for updating
@@ -61,6 +62,7 @@ export type ClientOptionsAxios = ClientOptions & {
  *
  * const endpoints: Endpoints = {
  *   search: 'resources/',
+ *   searchAllPages: 'resources/',
  *   fetch: 'resources/:id/',
  *   create: 'resources/',
  *   update: 'resources/:id/',
@@ -69,29 +71,11 @@ export type ClientOptionsAxios = ClientOptions & {
  */
 export type Endpoints = {
   search?: string;
+  searchAllPages?: string;
   fetch?: string;
   create?: string;
   update?: string;
   delete?: string;
-};
-
-/**
- * DataOptions type
- * @description Type for DataOptions
- * @typedef DataOptions
- * @property {object} [data] - The data to use for the request
- * @property {object} [params] - The query params to use for the request
- * @example
- * import { DataOptions } from './types';
- *
- * const dataOptions: DataOptions = {
- *   data: { name: 'John Doe' },
- *   params: { name: 'John Doe' }
- * }
- */
-export type DataOptions = {
-  data?: object;
-  params?: object;
 };
 
 /**
@@ -150,17 +134,61 @@ export type AuthOptions = {
   bearer?: BearerAuthOptions;
 };
 
-export type PayloadRequestZendesk = {
+/**
+ * Payload type
+ * @description Type for Payload Request Base
+ * @typedef Payload
+ * @property {string} url - The url to use for the request
+ * @property {string} method - The method to use for the request
+ * @property {object} [headers] - The headers to use for the request
+ * @property {object} [params] - The query params to use for the request
+ * @property {object|string} [data] - The data to use for the request
+ * @example
+ * import { Payload } from './types';
+ * const payload: Payload = {
+ *  url: 'https://api.example.com',
+ *  method: 'GET',
+ *  headers: { 'Content-Type': 'application/json' },
+ *  params: { name: 'John Doe' }
+ * }
+ */
+
+export type Payload = {
   url: string;
   method: string;
-  pathParams?: object;
-  queryParams?: object;
-  contentType?: string;
-  data?: object | string;
-  options?: object;
   headers?: object;
+  params?: object;
+  data?: object | string;
+};
+
+/**
+ * PayloadRequestZendesk type
+ * @description Type for Payload Request Zendesk
+ * @typedef PayloadRequestZendesk
+ * @property {Payload} [payload] - The payload to use for the request
+ * @property {object} [pathParams] - The path params to use for the request
+ * @property {string} [contentType] - The content type to use for the request
+ * @property {object} [options] - The options to use for the request
+ * @property {number} [retryCount] - The retry count to use for the request
+ */
+
+export type PayloadRequestZendesk = Payload & {
+  pathParams?: object;
+  contentType?: string;
+  options?: object;
   retryCount?: number;
 };
+
+/**
+ * Zendesk ModalProps type
+ * @description Type for Zendesk ModalProps
+ * @typedef ModalProps
+ * @property {string} modalName - The name of the Zendesk modal
+ * @property {string} modalUrl - The url of the Zendesk modal
+ * @property {object} size - The size of the Zendesk modal
+ * @property {string} size.width - The width of the Zendesk modal
+ * @property {string} size.height - The height of the Zendesk modal
+ */
 
 export type ModalProps = {
   modalName: string;
@@ -169,4 +197,83 @@ export type ModalProps = {
     width: string;
     height: string;
   };
+};
+
+/**
+ * PaginationConfigs type
+ * @description Type for PaginationConfigs
+ * @typedef PaginationConfigs
+ * @property {boolean} [nextEndpoint] - The next endpoint to use for the request
+ * @property {boolean} [nextCursor] - The next cursor to use for the request
+ * @property {string} [cursorEndpointProperty] - The cursor endpoint property to use for the request
+ * @property {string} recordProperty - The record property to use for the request
+ */
+
+export type PaginationConfigs = {
+  nextEndpoint?: boolean;
+  nextCursor?: boolean;
+  cursorEndpointProperty?: string;
+  recordProperty: string;
+};
+
+/**
+ * SearchAllPagesProps type
+ * @description Type for SearchAllPagesProps
+ * @typedef SearchAllPagesProps
+ * @property {string} strategy - The strategy to use for the request. 'cursor' | 'page' | 'offset'
+ * @property {PaginationConfigs} [paginationConfigs] - The pagination configs to use for the request
+ * @property {object} [params] - The params to use for the request
+ */
+
+export type SearchAllPagesProps = {
+  strategy: 'cursor' | 'page' | 'offset';
+  paginationConfigs?: PaginationConfigs;
+  params?: any;
+};
+
+/**
+ * SearchAllPagesResponse type
+ * @description Type for SearchAllPagesResponse
+ * @typedef SearchAllPagesResponse
+ * @property {any[]} dataFetched - The data fetched to use for the request
+ * @property {boolean} fullFetched - The full fetched to use for the request
+ */
+
+export type SearchAllPagesResponse = {
+  dataFetched: any[];
+  fullFetched: boolean;
+};
+
+/**
+ * SearchAllStrategyProps type
+ * @description Type for SearchAllStrategyProps
+ * @typedef SearchAllStrategyProps
+ * @property {any} data - The data to use for the request
+ * @property {PaginationConfigs} paginationConfigs - The pagination configs to use for the request
+ * @property {object} params - The params to use for the request
+ * @property {string} recordProperty - The record property to use for the request
+ * @property {string} endpoint - The endpoint to use for the request
+ */
+
+export type SearchAllStrategyProps = {
+  data: any;
+  paginationConfigs: PaginationConfigs;
+  params: any;
+  recordProperty: any;
+  endpoint: string;
+};
+
+/**
+ * SearchAllStrategyReturn type
+ * @description Type for SearchAllStrategyReturn
+ * @typedef SearchAllStrategyReturn
+ * @property {string} endpoint - The endpoint to use for the request
+ * @property {boolean} hasMore - The has more to use for the request
+ * @property {object} paramsAux - The params aux to use for the request
+ */
+
+export type SearchAllStrategyReturn = {
+  endpoint: string;
+  hasMore: boolean;
+  paramsAux: any;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,6 @@
+import { SearchAllStrategyProps, SearchAllStrategyReturn } from './types';
+
+/* eslint-disable no-prototype-builtins */
 export const queryParamsUrl = (url: string, params: any) => {
   const query = Object.keys(params)
     .map((k) => encodeURIComponent(k) + '=' + encodeURIComponent(params[k]))
@@ -12,3 +15,91 @@ export const converterPathParamsUrl = (url: string, params: any) => {
 };
 
 export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const getNestedProperty = (obj: any, path: string): any => {
+  // if(!path) return obj;
+  if (typeof obj !== 'object') return undefined;
+  if (!obj) return undefined;
+  const properties = path.split('.');
+  for (const property of properties) {
+    if (!obj.hasOwnProperty(property)) return undefined;
+    obj = obj[property];
+  }
+  return obj;
+};
+
+export const cursorStrategy = (
+  props: SearchAllStrategyProps
+): SearchAllStrategyReturn => {
+  const { data, paginationConfigs, params, endpoint } = props;
+  let endpointAux = endpoint;
+  let hasMore = true;
+  let paramsAux = { ...params };
+
+  const cursorProperty = getNestedProperty(
+    data,
+    paginationConfigs.cursorEndpointProperty || ''
+  );
+
+  if (paginationConfigs.nextEndpoint) {
+    endpointAux = cursorProperty;
+    paramsAux = null;
+  }
+
+  if (paginationConfigs.nextCursor && cursorProperty)
+    paramsAux = { ...params, cursor: cursorProperty };
+
+  if (!cursorProperty) hasMore = false;
+
+  return { endpoint: endpointAux, hasMore, paramsAux };
+};
+
+export const pageStrategy = (
+  props: SearchAllStrategyProps
+): SearchAllStrategyReturn => {
+  const { recordProperty, params, endpoint } = props;
+  const paramsAux = { ...params };
+  let hasMore = true;
+
+  if (
+    !recordProperty ||
+    (recordProperty && recordProperty.length < (paramsAux.perPage || 10))
+  ) {
+    hasMore = false;
+  } else {
+    paramsAux.page = (paramsAux.page || 1) + 1;
+  }
+
+  return { endpoint, hasMore, paramsAux };
+};
+
+export const offsetStrategy = (
+  props: SearchAllStrategyProps
+): SearchAllStrategyReturn => {
+  const { recordProperty, params, endpoint } = props;
+  const paramsAux = { ...params };
+  let hasMore = true;
+
+  if (
+    !recordProperty ||
+    (recordProperty && recordProperty.length < (paramsAux.limit || 10))
+  ) {
+    hasMore = false;
+  } else {
+    paramsAux.offset = (paramsAux.offset || 0) + (paramsAux.limit || 10);
+  }
+
+  return { endpoint, hasMore, paramsAux };
+};
+
+export const getStrategies = () => {
+  const strategies: {
+    [key: string]: (data: SearchAllStrategyProps) => SearchAllStrategyReturn;
+  } = {
+    cursor: cursorStrategy,
+    page: pageStrategy,
+    offset: offsetStrategy
+  };
+
+  return strategies;
+};

--- a/src/zendesk.ts
+++ b/src/zendesk.ts
@@ -13,6 +13,7 @@ export class ZendeskClient
   implements ZendeskClientInterface
 {
   isProduction: boolean;
+  timeout: number;
   clientOptions: ClientOptionsZendesk;
 
   constructor(clientOptions: ClientOptionsZendesk) {
@@ -20,6 +21,7 @@ export class ZendeskClient
     this.client = clientOptions.client;
     this.clientOptions = clientOptions;
     this.isProduction = clientOptions.secure || false;
+    this.timeout = clientOptions.timeout;
   }
 
   /**
@@ -31,8 +33,8 @@ export class ZendeskClient
     if (payload.pathParams)
       payload.url = converterPathParamsUrl(payload.url, payload.pathParams);
 
-    if (payload.queryParams)
-      payload.url = queryParamsUrl(payload.url, payload.queryParams);
+    if (payload.params)
+      payload.url = queryParamsUrl(payload.url, payload.params);
 
     try {
       return await this.client.request({
@@ -43,7 +45,9 @@ export class ZendeskClient
           ? payload.contentType
           : 'application/x-www-form-urlencoded',
         httpCompleteResponse: true,
-        ...(payload.data && { data: payload.data })
+        timeout: this.timeout,
+        ...(payload.data && { data: payload.data }),
+        ...(payload.headers && { headers: payload.headers })
       });
     } catch (error) {
       if (!error.status) throw new Error(String(error));

--- a/tests/axios.test.ts
+++ b/tests/axios.test.ts
@@ -213,7 +213,10 @@ describe('AxiosClient', () => {
     clientBasic.clientOptions.forceAuth = true;
     const data = { id: 1, name: 'test' };
     mock.onGet('/users').reply(200, data);
-    await clientBasic.makeRequest('get', '/users');
+    await clientBasic.makeRequest({
+      method: 'get',
+      url: '/users'
+    });
     expect(await clientBasic.authentication).toHaveBeenCalled();
   });
 
@@ -222,7 +225,10 @@ describe('AxiosClient', () => {
     clientBasic.retryAuth = true;
     const data = { id: 1, name: 'test' };
     mock.onGet('/users').reply(200, data);
-    await clientBasic.makeRequest('get', '/users');
+    await clientBasic.makeRequest({
+      method: 'get',
+      url: '/users'
+    });
     expect(await clientBasic.authentication).toHaveBeenCalled();
   });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,4 +1,13 @@
-import { converterPathParamsUrl, queryParamsUrl, sleep } from '../src/utils';
+import {
+  converterPathParamsUrl,
+  cursorStrategy,
+  getNestedProperty,
+  getStrategies,
+  offsetStrategy,
+  pageStrategy,
+  queryParamsUrl,
+  sleep
+} from '../src/utils';
 
 describe('queryParamsUrl', () => {
   it.each([
@@ -56,5 +65,296 @@ describe('sleep', () => {
     // Checks if the elapsed time is close to the specified time
     expect(elapsed).toBeGreaterThanOrEqual(ms);
     expect(elapsed).toBeLessThanOrEqual(ms + 10);
+  });
+});
+
+describe('getNestedProperty', () => {
+  it('should retrieve a top-level property', () => {
+    const obj = { a: 1 };
+    expect(getNestedProperty(obj, 'a')).toBe(1);
+  });
+
+  it('should retrieve a nested property', () => {
+    const obj = { a: { b: { c: 2 } } };
+    expect(getNestedProperty(obj, 'a.b.c')).toBe(2);
+  });
+
+  it('should return undefined if the path does not exist', () => {
+    const obj = { a: 1 };
+    expect(getNestedProperty(obj, 'a.b.c')).toBeUndefined();
+  });
+
+  it('should handle non-object inputs gracefully', () => {
+    expect(getNestedProperty(null, 'a.b.c')).toBeUndefined();
+    expect(getNestedProperty(undefined, 'a.b.c')).toBeUndefined();
+    expect(getNestedProperty(12345, 'a.b.c')).toBeUndefined();
+  });
+});
+
+describe('cursorStrategy', () => {
+  it('should return original endpoint and set hasMore to false if no cursorProperty is found', () => {
+    const expectedEndpoint = '/api/users';
+    const result = cursorStrategy({
+      data: { someData: 'value' },
+      paginationConfigs: { recordProperty: 'records' },
+      params: { someParam: 'value' },
+      endpoint: expectedEndpoint,
+      recordProperty: 'records'
+    });
+
+    expect(result).toEqual({
+      endpoint: expectedEndpoint,
+      hasMore: false,
+      paramsAux: { someParam: 'value' }
+    });
+  });
+
+  it('should set the endpoint as cursorProperty if nextEndpoint is present', () => {
+    const result = cursorStrategy({
+      data: { cursor: 'next_endpoint_value' },
+      paginationConfigs: {
+        nextEndpoint: true,
+        cursorEndpointProperty: 'cursor',
+        recordProperty: 'records'
+      },
+      params: {},
+      endpoint: '',
+      recordProperty: 'records'
+    });
+
+    expect(result.endpoint).toBe('next_endpoint_value');
+    expect(result.hasMore).toBe(true);
+    expect(result.paramsAux).toBe(null);
+  });
+
+  it('should add cursor to paramsAux if nextCursor is present and cursorProperty exists', () => {
+    const result = cursorStrategy({
+      data: { cursor: 'next_cursor_value' },
+      paginationConfigs: {
+        nextCursor: true,
+        cursorEndpointProperty: 'cursor',
+        recordProperty: 'records'
+      },
+      params: { existingParam: 'value' },
+      endpoint: '',
+      recordProperty: 'records'
+    });
+
+    expect(result.paramsAux).toEqual({
+      existingParam: 'value',
+      cursor: 'next_cursor_value'
+    });
+  });
+
+  it('should set hasMore to false if cursorProperty does not exist', () => {
+    const result = cursorStrategy({
+      data: { unrelatedProperty: 'value' },
+      paginationConfigs: {
+        cursorEndpointProperty: 'cursor',
+        recordProperty: 'records'
+      },
+      endpoint: '',
+      recordProperty: 'records',
+      params: {}
+    });
+
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('should preserve existing params', () => {
+    const result = cursorStrategy({
+      data: {},
+      paginationConfigs: { recordProperty: 'records' },
+      endpoint: '',
+      recordProperty: 'records',
+      params: { existingParam: 'value' }
+    });
+
+    expect(result.paramsAux).toEqual({ existingParam: 'value' });
+  });
+});
+
+describe('pageStrategy', () => {
+  it('should set hasMore to false if recordProperty length is less than perPage', () => {
+    const result = pageStrategy({
+      recordProperty: Array(5).fill(null),
+      params: { perPage: 10 },
+      endpoint: 'some_endpoint',
+      data: {},
+      paginationConfigs: { recordProperty: 'records' }
+    });
+
+    expect(result).toEqual({
+      endpoint: 'some_endpoint',
+      hasMore: false,
+      paramsAux: { perPage: 10 }
+    });
+  });
+
+  it('should increment the page if recordProperty length is not less than perPage', () => {
+    const result = pageStrategy({
+      recordProperty: Array(10).fill(null),
+      params: { perPage: 10, page: 1 },
+      endpoint: 'some_endpoint',
+      data: {},
+      paginationConfigs: { recordProperty: 'records' }
+    });
+
+    expect(result).toEqual({
+      endpoint: 'some_endpoint',
+      hasMore: true,
+      paramsAux: { perPage: 10, page: 2 }
+    });
+  });
+
+  it('should default to a perPage of 10 if not provided and increment page if recordProperty length matches default', () => {
+    const result = pageStrategy({
+      recordProperty: Array(10).fill(null),
+      params: { page: 1 },
+      endpoint: 'some_endpoint',
+      data: {},
+      paginationConfigs: { recordProperty: 'records' }
+    });
+
+    expect(result).toEqual({
+      endpoint: 'some_endpoint',
+      hasMore: true,
+      paramsAux: { page: 2 }
+    });
+  });
+
+  it('should default page to 2 if not provided and recordProperty length is not less than default perPage', () => {
+    const result = pageStrategy({
+      recordProperty: Array(10).fill(null),
+      params: {},
+      endpoint: 'some_endpoint',
+      data: {},
+      paginationConfigs: { recordProperty: 'records' }
+    });
+
+    expect(result).toEqual({
+      endpoint: 'some_endpoint',
+      hasMore: true,
+      paramsAux: { page: 2 }
+    });
+  });
+
+  it('should set hasMore to false if no recordProperty is provided', () => {
+    const result = pageStrategy({
+      params: {},
+      data: {},
+      paginationConfigs: { recordProperty: 'records' },
+      recordProperty: null,
+      endpoint: 'some_endpoint'
+    });
+
+    expect(result).toEqual({
+      endpoint: 'some_endpoint',
+      hasMore: false,
+      paramsAux: {}
+    });
+  });
+});
+
+describe('offsetStrategy', () => {
+  it('should set hasMore to false if recordProperty length is less than limit', () => {
+    const result = offsetStrategy({
+      recordProperty: Array(5).fill(null),
+      params: { limit: 10 },
+      endpoint: 'some_endpoint',
+      data: {},
+      paginationConfigs: { recordProperty: 'records' }
+    });
+
+    expect(result).toEqual({
+      endpoint: 'some_endpoint',
+      hasMore: false,
+      paramsAux: { limit: 10 }
+    });
+  });
+
+  it('should increment the offset by limit if recordProperty length is not less than limit', () => {
+    const result = offsetStrategy({
+      recordProperty: Array(10).fill(null),
+      params: { limit: 10, offset: 0 },
+      endpoint: 'some_endpoint',
+      data: {},
+      paginationConfigs: { recordProperty: 'records' }
+    });
+
+    expect(result).toEqual({
+      endpoint: 'some_endpoint',
+      hasMore: true,
+      paramsAux: { limit: 10, offset: 10 }
+    });
+  });
+
+  it('should default to a limit of 10 if not provided and increment offset by default limit if recordProperty length matches default', () => {
+    const result = offsetStrategy({
+      recordProperty: Array(10).fill(null),
+      params: { offset: 0 },
+      endpoint: 'some_endpoint',
+      data: {},
+      paginationConfigs: { recordProperty: 'records' }
+    });
+
+    expect(result).toEqual({
+      endpoint: 'some_endpoint',
+      hasMore: true,
+      paramsAux: { offset: 10 }
+    });
+  });
+
+  it('should default offset to 10 if not provided and recordProperty length is not less than default limit', () => {
+    const result = offsetStrategy({
+      recordProperty: Array(10).fill(null),
+      params: { limit: 10 },
+      endpoint: 'some_endpoint',
+      data: {},
+      paginationConfigs: { recordProperty: 'records' }
+    });
+
+    expect(result).toEqual({
+      endpoint: 'some_endpoint',
+      hasMore: true,
+      paramsAux: { limit: 10, offset: 10 }
+    });
+  });
+
+  it('should set hasMore to false if no recordProperty is provided', () => {
+    const result = offsetStrategy({
+      params: { limit: 10 },
+      endpoint: 'some_endpoint',
+      data: {},
+      paginationConfigs: { recordProperty: 'records' },
+      recordProperty: null
+    });
+
+    expect(result).toEqual({
+      endpoint: 'some_endpoint',
+      hasMore: false,
+      paramsAux: { limit: 10 }
+    });
+  });
+});
+
+describe('getStrategies', () => {
+  it('should return an object with the specified strategy functions', () => {
+    const strategies = getStrategies();
+
+    expect(typeof strategies).toBe('object');
+    expect(strategies.cursor).toBe(cursorStrategy);
+    expect(strategies.page).toBe(pageStrategy);
+    expect(strategies.offset).toBe(offsetStrategy);
+  });
+
+  it('should not have any extra strategies', () => {
+    const strategies = getStrategies();
+
+    const keys = Object.keys(strategies);
+    expect(keys.length).toBe(3);
+    expect(keys).toContain('cursor');
+    expect(keys).toContain('page');
+    expect(keys).toContain('offset');
   });
 });


### PR DESCRIPTION
Resolves #42 

**Description:**
* The client-core lacked a method to retrieve all data from an API, making it essential to provide this functionality to the library users.
* Additionally, the endpoint's update method had the PUT method hardcoded, but there was a requirement to also support the PATCH option.

**Type of change:**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
To provide an option for fetching data from all pages, and to enable the use of the PATCH method during endpoint updates.

---

**Checklist:**

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
