### PR TITLE
Fix/return zaf api error

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -274,7 +274,8 @@ export class BaseClient implements BaseClientInterface {
    * @throws {InvalidAuthOptions}
    */
   retryDelay = (retryCount: number, error: AxiosError | any): number => {
-    if (retryCount >= this.clientOptions.tries) throw error;
+    if (retryCount >= this.clientOptions.tries)
+      throw error.response ? error.response : error;
     return error.response.status ===
       HttpStatusCodesRetryCondition.TooManyRequests
       ? parseInt(error.response.headers[this.clientOptions.rateLimitKey])

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -1,3 +1,5 @@
+import { ZendeskError } from './types';
+
 /**
  * EndpointNotSet Error
  * @description
@@ -34,9 +36,12 @@ export class AuthProviderNotFound extends Error {
 
 export class ZendeskRequestError extends Error {
   response: object;
-  constructor(message: object) {
+  constructor(message: ZendeskError) {
     super(JSON.stringify(message));
     this.name = 'ZendeskRequestError';
-    this.response = message;
+    this.response = {
+      status: message.status,
+      message: message.message
+    };
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -277,3 +277,8 @@ export type SearchAllStrategyReturn = {
   hasMore: boolean;
   paramsAux: any;
 };
+
+export type ZendeskError = {
+  status: number;
+  message: string;
+};

--- a/src/zendesk.ts
+++ b/src/zendesk.ts
@@ -51,10 +51,16 @@ export class ZendeskClient
       });
     } catch (error) {
       if (!error.status) throw new Error(String(error));
-      const instanceError = new ZendeskRequestError(error);
+      const instanceError = new ZendeskRequestError({
+        status: error.status,
+        message: error.responseJSON.message
+      });
+
       if (this.retryCondition(instanceError)) {
         await sleep(this.retryDelay(payload.retryCount, instanceError));
         this.makeRequest(payload);
+      } else {
+        throw instanceError.response;
       }
     }
   }

--- a/tests/base.test.ts
+++ b/tests/base.test.ts
@@ -231,4 +231,14 @@ describe('BaseClient', () => {
     expect(result.fullFetched).toBe(true);
     expect(result.dataFetched).toEqual(['someData', 'someData2']);
   });
+
+  it('should throw with error response if exists on retryDelay', async () => {
+    try {
+      clientBasic.retryDelay(1, {
+        response: { status: 500, message: 'requestError' }
+      });
+    } catch (error) {
+      expect(error).toEqual({ status: 500, message: 'requestError' });
+    }
+  });
 });


### PR DESCRIPTION
Resolves #46 

**Description:**
_When extending the ZendeskClient, the makeRequest method fails to return the appropriate API call error._

**Type of change:**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
_ To make the makeRequest method relayed the error that the client's API returned._

---

**Checklist:**

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
