### PR TITLE
feat: change method to type on Zendesk requests

### DIFF
--- a/src/zendesk.ts
+++ b/src/zendesk.ts
@@ -44,7 +44,7 @@ export class ZendeskClient
     try {
       return await this.client.request({
         url: payload.url,
-        method: payload.method,
+        type: payload.method,
         secure: this.isProduction,
         contentType: payload.contentType
           ? payload.contentType

--- a/tests/zendesk.test.ts
+++ b/tests/zendesk.test.ts
@@ -242,7 +242,7 @@ describe('ZendeskClientBase', () => {
 
   it('should call makeRequest with the correct', async () => {
     const payload: PayloadRequestZendesk = {
-      url: 'test',
+      url: 'url',
       method: 'method'
     };
     await zendeskClientBase.makeRequest(payload);

--- a/tests/zendesk.test.ts
+++ b/tests/zendesk.test.ts
@@ -242,17 +242,19 @@ describe('ZendeskClientBase', () => {
 
   it('should call makeRequest with the correct', async () => {
     const payload: PayloadRequestZendesk = {
-      url: 'url',
+      url: 'test',
       method: 'method'
     };
     await zendeskClientBase.makeRequest(payload);
     delete payload.retryCount;
     expect(mockZendeskClient.request).toHaveBeenCalledWith({
-      ...payload,
+      url: payload.url,
+      type: payload.method,
       secure: false,
       timeout: 5000,
       contentType: 'application/x-www-form-urlencoded',
-      httpCompleteResponse: true
+      httpCompleteResponse: true,
+      headers: {}
     });
   });
 
@@ -338,11 +340,13 @@ describe('ZendeskClientBase', () => {
     await zendeskClientBase.makeRequest(payload);
     delete payload.retryCount;
     expect(mockZendeskClient.request).toHaveBeenCalledWith({
-      ...payload,
+      url: payload.url,
+      type: payload.method,
       secure: false,
       timeout: 5000,
       contentType: expectedContentType,
-      httpCompleteResponse: true
+      httpCompleteResponse: true,
+      headers: {}
     });
     expect(mockZendeskClient.request).toHaveBeenCalledTimes(1);
   });
@@ -357,12 +361,14 @@ describe('ZendeskClientBase', () => {
     await zendeskClientBase.makeRequest(payload);
     delete payload.retryCount;
     expect(mockZendeskClient.request).toHaveBeenCalledWith({
-      ...payload,
+      url: payload.url,
+      type: payload.method,
       secure: false,
       data: expectedData,
       httpCompleteResponse: true,
       timeout: 5000,
-      contentType: 'application/x-www-form-urlencoded'
+      contentType: 'application/x-www-form-urlencoded',
+      headers: {}
     });
     expect(mockZendeskClient.request).toHaveBeenCalledTimes(1);
   });
@@ -405,7 +411,8 @@ describe('ZendeskClientBase', () => {
     delete payload.retryCount;
 
     expect(mockZendeskClient.request).toHaveBeenCalledWith({
-      ...payload,
+      url: payload.url,
+      type: payload.method,
       secure: false,
       headers: expectedHeader,
       httpCompleteResponse: true,


### PR DESCRIPTION
**Description:**
_Replace the non-existent "method" property in the Zendesk request with the correct property, "type", for methods other than GET._

**Type of change:**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
_This error prevents requests other than GET from being executed using the library._

---

**Checklist:**

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
