### PR TITLE
fix: adding suport to amazon JSON content type in the getToken request

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -123,10 +123,9 @@ export class BearerAuthZendesk extends BaseBearerAuth implements AuthBasic {
         dataType: this.authOptions.dataType || 'json',
         httpCompleteResponse: true,
         contentType: contentType || ContentTypes.X_URL_ENCODED,
-        data:
-          jsonContentTypes.includes(contentType)
-            ? JSON.stringify(this.authOptions.bearer.data)
-            : this.authOptions.bearer.data,
+        data: jsonContentTypes.includes(contentType)
+          ? JSON.stringify(this.authOptions.bearer.data)
+          : this.authOptions.bearer.data,
         headers: this.authOptions.bearer.headers || {},
         timeout: this.authOptions.timeout || 5000
       });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError, AxiosInstance } from 'axios';
 
-import { ContentTypes } from './enums';
+import { ContentTypes, jsonContentTypes } from './enums';
 import { ZendeskRequestError } from './exceptions';
 import { AuthBasic } from './interfaces';
 import { AuthOptions, AuthOptionsZendesk } from './types';
@@ -124,7 +124,7 @@ export class BearerAuthZendesk extends BaseBearerAuth implements AuthBasic {
         httpCompleteResponse: true,
         contentType: contentType || ContentTypes.X_URL_ENCODED,
         data:
-          contentType === ContentTypes.JSON
+          jsonContentTypes.includes(contentType)
             ? JSON.stringify(this.authOptions.bearer.data)
             : this.authOptions.bearer.data,
         headers: this.authOptions.bearer.headers || {},

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -123,7 +123,7 @@ export class BearerAuthZendesk extends BaseBearerAuth implements AuthBasic {
         dataType: this.authOptions.dataType || 'json',
         httpCompleteResponse: true,
         contentType: contentType || ContentTypes.X_URL_ENCODED,
-        data: jsonContentTypes.includes(contentType)
+        data: jsonContentTypes.includes(contentType as ContentTypes)
           ? JSON.stringify(this.authOptions.bearer.data)
           : this.authOptions.bearer.data,
         headers: this.authOptions.bearer.headers || {},

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -62,10 +62,8 @@ export enum HtttpStatusCodeError {
 
 export enum ContentTypes {
   JSON = 'application/json',
+  AMZ_JSON_1_1 = 'application/x-amz-json-1.1',
   X_URL_ENCODED = 'application/x-www-form-urlencoded'
 }
 
-export const jsonContentTypes = [
-  'application/json',
-  'application/x-amz-json-1.1'
-];
+export const jsonContentTypes = [ContentTypes.JSON, ContentTypes.AMZ_JSON_1_1];

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -64,3 +64,5 @@ export enum ContentTypes {
   JSON = 'application/json',
   X_URL_ENCODED = 'application/x-www-form-urlencoded'
 }
+
+export const jsonContentTypes = ['application/json', 'application/x-amz-json-1.1']; 

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -65,4 +65,7 @@ export enum ContentTypes {
   X_URL_ENCODED = 'application/x-www-form-urlencoded'
 }
 
-export const jsonContentTypes = ['application/json', 'application/x-amz-json-1.1']; 
+export const jsonContentTypes = [
+  'application/json',
+  'application/x-amz-json-1.1'
+];


### PR DESCRIPTION
Mudança no método `getBearerToken()` da classe `BearerAuth` para considerar o contentType padrão de autenticação no cognito `application/x-amz-json-1.1`.

Da forma como está hoje, a requisição de login para _**https://cognito-idp.us-east-1.amazonaws.com/**_
esta sendo enviada com contentType errado.

<img width="658" alt="Screenshot 2024-11-18 at 02 04 58" src="https://github.com/user-attachments/assets/3bd0d6d5-64c4-4555-ace4-a13fc9052c5a">


