### PR TITLE
fix: triggers modal ready event to new ticket sidebar too

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -240,6 +240,7 @@ export type ModalProps = {
 };
 
 export type InstanceLocations =
+  | 'new_ticket_sidebar'
   | 'ticket_sidebar'
   | 'nav_bar'
   | 'modal'

--- a/src/zendesk.ts
+++ b/src/zendesk.ts
@@ -211,7 +211,7 @@ export class ZendeskClient
   async modalReady() {
     await this.triggerToLocations({
       event: `modal.ready`,
-      locations: ['nav_bar', 'ticket_sidebar', 'top_bar']
+      locations: ['nav_bar', 'new_ticket_sidebar', 'ticket_sidebar', 'top_bar']
     });
   }
 

--- a/tests/zendesk.test.ts
+++ b/tests/zendesk.test.ts
@@ -550,7 +550,7 @@ describe('ZendeskClientBase', () => {
 
     expect(zendeskClientBase.triggerToLocations).toHaveBeenCalledWith({
       event: 'modal.ready',
-      locations: ['nav_bar', 'ticket_sidebar', 'top_bar']
+      locations: ['nav_bar', 'new_ticket_sidebar', 'ticket_sidebar', 'top_bar']
     });
   });
 


### PR DESCRIPTION
**Descrição:**
_Resolvendo um bug antigo no client core, que faz com que o modal nunca emita o evento de ready para a location New Ticket Sidebar_